### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pull_to_dismiss_pager = (PullToDismissPager) findViewById(R.id.pull_to_dismiss_p
 pagerAdapter = new SlidingPagerAdapter(this);
 pull_to_dismiss_pager.setPagerAdapter(pagerAdapter);
 ```
-###ToDo
+### ToDo
 Add some easing to animations
 ### Licence
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
